### PR TITLE
Fixes #108

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -184,7 +184,7 @@ packageEnv <- function(exportenv, packages=NULL, version="3.1.0") {
     if(is.null(re)) re = c(CRAN="http://cran.revolutionanalytics.com")
     p = paste(d,"packages",sep="/")
     tryCatch(dir.create(p), warning=function(e) stop(e))
-    tryCatch(makeRepo(pkgDep(packages, repos=re, suggests=FALSE), path=p, re, type="win.binary", Rversion=version),
+    tryCatch(makeRepo(pkgDep(packages, repos=re, suggests=FALSE, type="win.binary"), path=p, re, type="win.binary", Rversion=version),
              error=function(e) stop(e))
   }
   

--- a/R/internal.R
+++ b/R/internal.R
@@ -184,7 +184,8 @@ packageEnv <- function(exportenv, packages=NULL, version="3.1.0") {
     if(is.null(re)) re = c(CRAN="http://cran.revolutionanalytics.com")
     p = paste(d,"packages",sep="/")
     tryCatch(dir.create(p), warning=function(e) stop(e))
-    tryCatch(makeRepo(pkgDep(packages, repos=re, suggests=FALSE, type="win.binary"), path=p, re, type="win.binary", Rversion=version),
+    tryCatch(makeRepo(pkgDep(packages, repos=re, suggests=FALSE, type="win.binary", Rversion=version), 
+                      path=p, re, type="win.binary", Rversion=version),
              error=function(e) stop(e))
   }
   


### PR DESCRIPTION
Using "win.binary" for all repository operations allows AzureML to work with a purely binary repository, simplifying things for custom R packages or manually updating package versions.